### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/AD5689/AD5689/library.properties
+++ b/AD5689/AD5689/library.properties
@@ -7,4 +7,4 @@ paragraph=Simple driver for Analog Devices AD5689
 category=Signal Input/Output
 url=https://github/AD5689
 architectures=*
-includes=SPI.h
+includes=AD5689.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > AD5689**. This field should specify the primary header file(s) of the library.

Support for the `includes` field was added in Arduino IDE 1.6.10. That IDE version and newer don't require `#include` directives for dependencies of libraries. Thus, there is no need to specify those in the library.properties `includes` field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format